### PR TITLE
Arrumar testes no CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,5 @@ jobs:
           key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - "node_modules"
-      - run: npm run test -- --single-run --no-progress --browser=ChromeHeadlessCI
+      - run: npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessCI
       - run: npm run e2e -- --no-progress --config=protractor-ci.conf.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,4 @@ jobs:
           paths:
             - "node_modules"
       - run: npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessCI
-      - run: npm run e2e -- --no-progress --config=protractor-ci.conf.js
+      - run: npm run e2e -- --config=protractor-ci.conf.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,4 @@ jobs:
           paths:
             - "node_modules"
       - run: npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessCI
-      - run: npm run e2e -- --config=protractor-ci.conf.js
+      - run: npm run e2e -- --protractor-config=e2e/protractor.conf.js


### PR DESCRIPTION
# O que foi feito

* Substituir flags antigas na execução dos testes
    * `--single-run` vira `--watch=false` (angular/angular-cli#10711)
    * `--browser` vira `--browsers` (angular/angular-cli#10920)
    * E nos testes e2e: `--config` vira `--protractor-config`. O caminho do arquivo estava errado também. (angular/angular-cli#10677)

# Por que foi feito

Para que os testes possam ser executados corretamente no CircleCI.
